### PR TITLE
Fix to event 901116 in Ausgleich.txt

### DIFF
--- a/db/events/Mitteleuropa/AUSGLEICH.txt
+++ b/db/events/Mitteleuropa/AUSGLEICH.txt
@@ -1305,11 +1305,11 @@ desc = "We have finally declared our independence from the opressive and incompe
 style = 2
 
 action_a = {
-name = "István Bethlen shall lead us!"
+name = "IstvÃ¡n Bethlen shall lead us!"
 command = { type = end_non_aggression which = AUS where = HUN }
 command = { type = end_non_aggression which = HUN where = AUS }
-command = { type = headofstate which = 21185 } #István Bethlen
-command = { type = headofgovernment which = 21186 } #Pál Teleki
+command = { type = headofstate which = 21185 } #IstvÃ¡n Bethlen
+command = { type = headofgovernment which = 21186 } #PÃ¡l Teleki
 command = { type = dissent value = -10 }
 command = { type = removecore which = 211 }
 command = { type = removecore which = 212 }
@@ -1324,9 +1324,9 @@ command = { type = add_division value = infantry when = 8 }
 command = { type = add_division value = infantry when = 8 }
 command = { type = add_division value = cavalry when = 7 }
 command = { type = add_division value = cavalry when = 7 }
-command = { type = add_corps which = "Nyilas milícia" value = land when = -1 where = 284 }
-command = { type = add_division which = "1.Nyilas milícia" value = militia when = 4 }
-command = { type = add_division which = "2.Nyilas milícia" value = militia when = 4 }
+command = { type = add_corps which = "Nyilas milÃ­cia" value = land when = -1 where = 284 }
+command = { type = add_division which = "1.Nyilas milÃ­cia" value = militia when = 4 }
+command = { type = add_division which = "2.Nyilas milÃ­cia" value = militia when = 4 }
 command = { type = supplies value = 500 }
 command = { type = money value = 75 }
 command = { type = end_guarantee which = GER where = GLD }
@@ -2401,7 +2401,7 @@ trigger = {
 war = { country = AUS country = HUN }
 owned = { province = 400 data = AUS }
 owned = { province = 401 data = AUS }
-NOT = {  headofstate = 3257 } #Josef I von Österreich-Toskana
+NOT = {  headofstate = 3257 } #Josef I von Ã–sterreich-Toskana
 NOT = {
 atwar = ITA
 ispuppet = ITA
@@ -2577,7 +2577,7 @@ NOT = { alliance = { country = FRA country = AUS } }
 }
 
 name = "Peace with Italy?"
-desc = "We have succesfully defended our Italian provinces against Italian onslaught and launched counterattack, which brought us before the gates of Rome ! Because of Italy´s weak position, they probably have no chance to push us back, and would probably accept a peace offer."
+desc = "We have succesfully defended our Italian provinces against Italian onslaught and launched counterattack, which brought us before the gates of Rome ! Because of ItalyÂ´s weak position, they probably have no chance to push us back, and would probably accept a peace offer."
 picture = "austrohunarmy_march"
 
 date = { day = 1 month = january year = 1936 }
@@ -2684,7 +2684,7 @@ command = { type = removecore   which =  394  }
 command = { type = removecore   which =  405  }
 command = { type = removecore   which =  402  }
 command = { type = removecore   which =  404  }
-command = { type = headofstate which = 3257 } #Josef I von Österreich-Toskana
+command = { type = headofstate which = 3257 } #Josef I von Ã–sterreich-Toskana
 command = { type = headofgovernment which = 3245  } #Stephen X
 command = { type = set_domestic which = democratic value = 4 }
 command = { type = set_domestic which = political_left value = 4 }
@@ -2765,7 +2765,7 @@ NOT = { alliance = { country = FRA country = U24 } }
 }
 
 name = "Peace with Italy?"
-desc = "We have succesfully defended our Italian provinces against Italian onslaught and launched counterattack, which brought us before the gates of Rome ! Because of Italy´s weak position, they probably have no chance to push us back, and would probably accept a peace offer."
+desc = "We have succesfully defended our Italian provinces against Italian onslaught and launched counterattack, which brought us before the gates of Rome ! Because of ItalyÂ´s weak position, they probably have no chance to push us back, and would probably accept a peace offer."
 picture = "austrohunarmy_march"
 
 date = { day = 1 month = january year = 1936 }
@@ -2872,7 +2872,7 @@ command = { type = removecore   which =  394  }
 command = { type = removecore   which =  405  }
 command = { type = removecore   which =  402  }
 command = { type = removecore   which =  404  }
-command = { type = headofstate which = 3257 } #Josef I von Österreich-Toskana
+command = { type = headofstate which = 3257 } #Josef I von Ã–sterreich-Toskana
 command = { type = headofgovernment which = 3245  } #Stephen X
 command = { type = set_domestic which = democratic value = 4 }
 command = { type = set_domestic which = political_left value = 4 }
@@ -2953,7 +2953,7 @@ NOT = { alliance = { country = FRA country = U25 } }
 }
 
 name = "Peace with Italy?"
-desc = "We have succesfully defended our Italian provinces against Italian onslaught and launched counterattack, which brought us before the gates of Rome ! Because of Italy´s weak position, they probably have no chance to push us back, and would probably accept a peace offer."
+desc = "We have succesfully defended our Italian provinces against Italian onslaught and launched counterattack, which brought us before the gates of Rome ! Because of ItalyÂ´s weak position, they probably have no chance to push us back, and would probably accept a peace offer."
 picture = "austrohunarmy_march"
 
 date = { day = 1 month = january year = 1936 }
@@ -3060,7 +3060,7 @@ command = { type = removecore   which =  394  }
 command = { type = removecore   which =  405  }
 command = { type = removecore   which =  402  }
 command = { type = removecore   which =  404  }
-command = { type = headofstate which = 3257 } #Josef I von Österreich-Toskana
+command = { type = headofstate which = 3257 } #Josef I von Ã–sterreich-Toskana
 command = { type = headofgovernment which = 3245  } #Stephen X
 command = { type = set_domestic which = democratic value = 4 }
 command = { type = set_domestic which = political_left value = 4 }
@@ -5419,7 +5419,7 @@ command = { type = add_corps which = "Slovensky dobrovolnicky zbor" value = land
 command = { type = add_division which = "1. Pesia divizia" value = infantry when = 8 }
 }
 action_b = {
-name = "We don´t need them !" # Are you mad ?
+name = "We donÂ´t need them !" # Are you mad ?
 ai_chance = 0
 command = { type = dissent value = 5 }
 }
@@ -5567,7 +5567,7 @@ command = { type = add_division value = militia when = 4 }
 command = { type = add_division value = militia when = 4 }
 }
 action_b = {
-name = "We don´t need them !" # Are you mad ?
+name = "We donÂ´t need them !" # Are you mad ?
 ai_chance = 0
 command = { type = dissent value = 5 }
 }
@@ -5597,7 +5597,7 @@ command = { type = add_division value = militia when = 4 }
 command = { type = sleepevent which = 901581 }
 }
 action_b = {
-name = "We don´t need them !" # Are you mad ?
+name = "We donÂ´t need them !" # Are you mad ?
 ai_chance = 0
 command = { type = dissent value = 5 }
 command = { type = sleepevent which = 901581 }
@@ -6365,7 +6365,7 @@ command = { type = dissent value = 2 }
 action_c = {
 ai_chance = 50
 trigger = { NOT =  { guarantee = { country = GER country = AUS } alliance = { country = GER country = POL } } }
-name = "We don´t your permission to take back what is ours !"
+name = "We donÂ´t your permission to take back what is ours !"
 command = { type = addcore  which =  235 }
 command = { type = addcore  which =  236 }
 command = { type = addcore  which =  237 }
@@ -6519,7 +6519,7 @@ command = { type = removeclaim   which =  240  }
 command = { type = removeclaim   which =  301  }
 }
 action_b = {
-name = "We don´t need them !" # Are you mad ?
+name = "We donÂ´t need them !" # Are you mad ?
 ai_chance = 0
 command = { type = dissent value = 5 }
 }
@@ -6645,7 +6645,7 @@ picture = "crownofslovak"
 
 action_a = {
 ai_chance = 70
-name = "Václav V will be our king"
+name = "VÃ¡clav V will be our king"
 command = { type = trigger which = 901136 }
 }
 
@@ -6663,7 +6663,7 @@ country = CZE
 style = 2
 
 name = "Coronation of the new king"
-desc = "Zdenek Sterberk was crowned a new king of Bohemia under name Václav V in the sacred cathedral of St. Vitus "
+desc = "Zdenek Sterberk was crowned a new king of Bohemia under name VÃ¡clav V in the sacred cathedral of St. Vitus "
 picture = "slokingelec"
 
 action_a = {
@@ -7544,7 +7544,7 @@ command = { type = sleepevent which = 901087 }
 }
 action_c = {
 ai_chance = 20
-name = "The Hungarian, László Bárdossy"
+name = "The Hungarian, LÃ¡szlÃ³ BÃ¡rdossy"
 command = { type = headofgovernment which = 29641 }
 command = { type = set_domestic which = democratic value = 4 }
 command = { type = set_domestic which = political_left value = 4 }
@@ -7670,7 +7670,7 @@ date = { day = 1 month = january year = 1936 }
 offset = 5
 deathdate = { day = 29 month = december year = 1960 }
 
-name = "Bárdossy decides on the cabinet"
+name = "BÃ¡rdossy decides on the cabinet"
 desc = "Now we must choose who will be in the cabinet. There are three factions: The Conservative party with a Hungarian minority, the Aristrocrats and the third faction is evenly split in Hungarians and Austrian!"
 picture = "AUSHUN"
 
@@ -7736,12 +7736,12 @@ command = { type = headofgovernment which = 151246111 }
 }
 action = {
 ai_chance = 30
-name = "The Hungarian, Zoltán Tildy"
+name = "The Hungarian, ZoltÃ¡n Tildy"
 command = { type = headofgovernment which = 151246178 }
 }
 action = {
 ai_chance = 20
-name = "The Bohemian - Josef Bíly"
+name = "The Bohemian - Josef BÃ­ly"
 command = { type = headofgovernment which = 151246226 }
 }
 action = {
@@ -8686,7 +8686,7 @@ name = "YES!"
 command = { type = set_relation which = U25 value = 200 }
 command = { type = dissent value = -7 }
 command = { type = domestic which = defense_lobby value = 1 }
-command = { type = trigger which = 901113 }
+command = { type = trigger which = 901117 }
 }
 
 action_b = {


### PR DESCRIPTION
Option for Poland accepting Danubian Federation's (U25) alliance request points to wrong event (901113, Russian acceptance notification for U25)).  Changing it to point to correct event (901117, Polish acceptance notification for U25).