### PR TITLE
Fix spelling for Polish Sejm

### DIFF
--- a/db/events/Neutral Europe/Commonwealth.txt
+++ b/db/events/Neutral Europe/Commonwealth.txt
@@ -595,7 +595,7 @@ ideology = paternal_autocrat
 flag = COM_DEMOCRACY
 }
 
-name = "The Sejim Elections"
+name = "The Sejm Elections"
 desc = "Under our constitution, elections must be held every four years. There are four main political parties that have a chance of winning at the ballot box, who will it be?"
 picture = "election"
 
@@ -827,7 +827,7 @@ flag = COM_DEMOCRACY
 event = { id = 9981011 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
+name = "The Sejm Elections"
 desc = "Under our constitution, elections must be held every four years. There are three main political parties that have a chance to win at the ballot box, who will it be?"
 picture = "election"
 
@@ -903,7 +903,7 @@ flag = COM_DEMOCRACY
 event = { id = 9981012 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
+name = "The Sejm Elections"
 desc = "Under our constitution, elections must be held every four years. There are three main political parties that have a chance to win at the ballot box, who will it be?"
 picture = "election"
 
@@ -980,7 +980,7 @@ flag = COM_DEMOCRACY
 event = { id = 9981013 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
+name = "The Sejm Elections"
 desc = "Under our constitution, elections must be held every four years. There are three main political parties that have a chance to win at the ballot box, who will it be?"
 picture = "election"
 
@@ -1057,7 +1057,7 @@ flag = COM_DEMOCRACY
 event = { id = 9981014 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
+name = "The Sejm Elections"
 desc = "Under our constitution, elections must be held every four years. There are three main political parties that have a chance to win at the ballot box, who will it be?"
 picture = "election"
 

--- a/db/events/Neutral Europe/Poland.txt
+++ b/db/events/Neutral Europe/Poland.txt
@@ -1558,8 +1558,8 @@ ispuppet = POL
 }
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only four major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only four major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 18 month = january year = 1936 }
@@ -1692,8 +1692,8 @@ headofstate = 13178
 flag = POL_CONMON
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only four major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only four major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 18 month = january year = 1936 }
@@ -1853,8 +1853,8 @@ headofstate = 13178
 event = { id = 9980072 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 1 month = january year = 1936 }
@@ -1947,8 +1947,8 @@ trigger = { flag = POL_REPUBLIC
 event = { id = 9980071 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 1 month = january year = 1936 }
@@ -2019,8 +2019,8 @@ headofstate = 13178
 }
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 1 month = january year = 1936 }
@@ -2113,8 +2113,8 @@ trigger = { flag = POL_REPUBLIC
 event = { id = 9980080 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 1 month = january year = 1936 }
@@ -2174,8 +2174,8 @@ trigger = { flag = POL_REPUBLIC
 event = { id = 9980085 days = 1460 } #4 years
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 1 month = january year = 1936 }
@@ -2243,8 +2243,8 @@ headofstate = 13178
 }
 }
 
-name = "The Sejim Elections"
-desc = "As stated in our Constitution, elections for the Sejim must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
+name = "The Sejm Elections"
+desc = "As stated in our Constitution, elections for the Sejm must be held every four years. There are only three major parties that have a chance of gaining a majority, who will it be?"
 picture = "election"
 
 date = { day = 1 month = january year = 1936 }


### PR DESCRIPTION
Polish parliament is called "Sejm". That's also it's historical name. "Sejim" has no basis anywhere and looks as if someone was incorrectly guessing the spelling. See https://en.wikipedia.org/wiki/Sejm